### PR TITLE
feat: add carsonoid refactor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/bradleyshawkins/go-clean-architecture
 
 go 1.19
 
-require github.com/go-chi/chi/v5 v5.0.7 // indirect
+require github.com/go-chi/chi/v5 v5.0.7

--- a/refactored-carsonoid/handlers/filedownloader.go
+++ b/refactored-carsonoid/handlers/filedownloader.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/bradleyshawkins/go-clean-architecture/refactored-carsonoid/integrations"
+)
+
+// FileDownloader is a handler that will download a file from a url and import it into a system
+type FileDownloader struct {
+	integrations.DocumentImporter
+	integrations.DocumentDownloader
+
+	insertsEnabled bool
+}
+
+func NewFileDownloader(downloader integrations.DocumentDownloader, importer integrations.DocumentImporter) http.HandlerFunc {
+	return (&FileDownloader{
+		DocumentDownloader: downloader,
+		DocumentImporter:   importer,
+		insertsEnabled:     true,
+	}).handler
+}
+
+func (f *FileDownloader) handler(w http.ResponseWriter, r *http.Request) {
+	if !f.canInsertDocument() {
+		// close signals that we are done with the request and we are not going to read it
+		_ = r.Body.Close()
+		http.Error(w, "inserts are disabled", http.StatusServiceUnavailable)
+		return
+	}
+
+	doc := &integrations.Document{}
+	err := json.NewDecoder(r.Body).Decode(doc)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	fmt.Println("Received request to download file from:", doc.DownloadURL)
+
+	reader, err := f.DownloadDocument(r.Context(), doc)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	err = f.ImportDocument(r.Context(), doc, reader)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"status": "success",
+	})
+}
+
+func (f *FileDownloader) canInsertDocument() bool {
+	return f.insertsEnabled
+}

--- a/refactored-carsonoid/handlers/filedownloader_test.go
+++ b/refactored-carsonoid/handlers/filedownloader_test.go
@@ -1,0 +1,141 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/bradleyshawkins/go-clean-architecture/refactored-carsonoid/integrations"
+)
+
+type fakeDocumentImporter struct {
+	importErr error
+}
+
+func (f *fakeDocumentImporter) ImportDocument(ctx context.Context, doc *integrations.Document, r io.Reader) error {
+	return f.importErr
+}
+
+type fakeDocumentDownloader struct {
+	downloadResp *os.File
+	downloadErr  error
+}
+
+func (f *fakeDocumentDownloader) DownloadDocument(ctx context.Context, doc *integrations.Document) (*os.File, error) {
+	return f.downloadResp, f.downloadErr
+}
+
+func TestFileDownloader_handler(t *testing.T) {
+	type fields struct {
+		DocumentImporter   integrations.DocumentImporter
+		DocumentDownloader integrations.DocumentDownloader
+		insertsEnabled     bool
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		newRequest func() *http.Request
+		wantCode   int
+	}{
+		{
+			name: "inserts are disabled",
+			fields: fields{
+				insertsEnabled: false,
+			},
+			newRequest: func() *http.Request {
+				return httptest.NewRequest(http.MethodPost, "/download", nil)
+			},
+			wantCode: http.StatusServiceUnavailable,
+		},
+		{
+			name: "bad request body",
+			fields: fields{
+				insertsEnabled: true,
+			},
+			newRequest: func() *http.Request {
+				return httptest.NewRequest(http.MethodPost, "/download", nil)
+			},
+			wantCode: http.StatusBadRequest,
+		},
+		{
+			name: "download error",
+			fields: fields{
+				insertsEnabled:     true,
+				DocumentImporter:   &fakeDocumentImporter{},
+				DocumentDownloader: &fakeDocumentDownloader{downloadErr: errors.New("download error")},
+			},
+			newRequest: func() *http.Request {
+				body, err := json.Marshal(integrations.Document{
+					DownloadURL: "http://example.com",
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				return httptest.NewRequest(http.MethodPost, "/download", bytes.NewBuffer(body))
+			},
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name: "import error",
+			fields: fields{
+				insertsEnabled:     true,
+				DocumentImporter:   &fakeDocumentImporter{importErr: errors.New("import error")},
+				DocumentDownloader: &fakeDocumentDownloader{},
+			},
+			newRequest: func() *http.Request {
+				body, err := json.Marshal(integrations.Document{
+					DownloadURL: "http://example.com",
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				return httptest.NewRequest(http.MethodPost, "/download", bytes.NewBuffer(body))
+			},
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			name: "success",
+			fields: fields{
+				insertsEnabled:     true,
+				DocumentImporter:   &fakeDocumentImporter{},
+				DocumentDownloader: &fakeDocumentDownloader{},
+			},
+			newRequest: func() *http.Request {
+				body, err := json.Marshal(integrations.Document{
+					DownloadURL: "http://example.com",
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				return httptest.NewRequest(http.MethodPost, "/download", bytes.NewBuffer(body))
+			},
+			wantCode: http.StatusOK,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &FileDownloader{
+				DocumentImporter:   tt.fields.DocumentImporter,
+				DocumentDownloader: tt.fields.DocumentDownloader,
+				insertsEnabled:     tt.fields.insertsEnabled,
+			}
+
+			rec := httptest.NewRecorder()
+
+			f.handler(rec, tt.newRequest())
+
+			if rec.Code != tt.wantCode {
+				t.Errorf("FileDownloader.handler() code = %v, want %v", rec.Code, tt.wantCode)
+			}
+		})
+	}
+}

--- a/refactored-carsonoid/handlers/router.go
+++ b/refactored-carsonoid/handlers/router.go
@@ -1,0 +1,23 @@
+package handlers
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/bradleyshawkins/go-clean-architecture/refactored-carsonoid/integrations"
+	"github.com/go-chi/chi/v5"
+)
+
+// NewMux creates a new chi.Mux and registers the handlers
+func NewMux() *chi.Mux {
+	m := chi.NewMux()
+
+	web := integrations.NewWebIntegration(&http.Client{
+		Timeout: 10 * time.Second,
+	})
+	noop := integrations.NewNoopIntegration()
+
+	m.Post("/download", NewFileDownloader(web, noop))
+
+	return m
+}

--- a/refactored-carsonoid/integrations/document.go
+++ b/refactored-carsonoid/integrations/document.go
@@ -1,0 +1,9 @@
+package integrations
+
+// A Document is a document that can be downloaded and imported
+type Document struct {
+	DownloadURL string `json:"downloadURL"`
+	DocumentID  string `json:"documentID"`
+	CategoryID  string `json:"categoryID"`
+	PatientID   string `json:"patientID"`
+}

--- a/refactored-carsonoid/integrations/interfaces.go
+++ b/refactored-carsonoid/integrations/interfaces.go
@@ -1,0 +1,17 @@
+package integrations
+
+import (
+	"context"
+	"io"
+	"os"
+)
+
+// A DocumentDownloader should download a document using metadata from the Document and return a file handle
+type DocumentDownloader interface {
+	DownloadDocument(ctx context.Context, doc *Document) (*os.File, error)
+}
+
+// A DocumentImporter should import a document using metadata from the Document and the file handle
+type DocumentImporter interface {
+	ImportDocument(ctx context.Context, doc *Document, file io.Reader) error
+}

--- a/refactored-carsonoid/integrations/noop.go
+++ b/refactored-carsonoid/integrations/noop.go
@@ -1,0 +1,35 @@
+package integrations
+
+import (
+	"context"
+	"io"
+	"os"
+)
+
+// ensure that NoopIntegration implements DocumentImporter and DocumentDownloader
+var _ DocumentImporter = (*NoopIntegration)(nil)
+var _ DocumentDownloader = (*NoopIntegration)(nil)
+
+// NoopIntegration is an integration that will do nothing
+type NoopIntegration struct{}
+
+// NewNoopIntegration creates a new NoopIntegration
+func NewNoopIntegration() *NoopIntegration {
+	return &NoopIntegration{}
+}
+
+// DownloadDocument will return a file handle to a new, empty tempfile, the document is not actually
+// inserted but the file handle is returned to simulate the download
+func (i *NoopIntegration) DownloadDocument(ctx context.Context, doc *Document) (*os.File, error) {
+	tmpFile, err := os.CreateTemp("", "noop-*.jpg")
+	if err != nil {
+		return nil, err
+	}
+
+	return tmpFile, nil
+}
+
+// ImportDocument will do nothing, it will return nil to simulate the import as a noop
+func (i *NoopIntegration) ImportDocument(ctx context.Context, doc *Document, file io.Reader) error {
+	return nil
+}

--- a/refactored-carsonoid/integrations/web.go
+++ b/refactored-carsonoid/integrations/web.go
@@ -1,0 +1,97 @@
+package integrations
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+)
+
+// ensure that WebIntegration implements DocumentImporter
+var _ DocumentDownloader = (*WebIntegration)(nil)
+
+// WebIntegration is an integration that will download documents from a url
+type WebIntegration struct {
+	client *http.Client
+}
+
+// NewWebIntegration creates a new WebIntegration, it will use the
+// provided http.Client if provided. Otherwise it will create a new one
+//
+// > If the client has no Timeout set, it will be set to 10 seconds
+func NewWebIntegration(client *http.Client) *WebIntegration {
+	if client == nil {
+		client = &http.Client{}
+	}
+
+	if client.Timeout <= 0 {
+		client.Timeout = 10 * time.Second
+	}
+
+	return &WebIntegration{
+		client: client,
+	}
+}
+
+// DownloadDocument will download the document from the provided url to a tmpdir and return the file handle
+// it is the callers responsibility to close the file handle and delete the file
+func (i *WebIntegration) DownloadDocument(ctx context.Context, doc *Document) (*os.File, error) {
+	fmt.Println("Downloading a document with the web integration")
+	tmpFile, err := os.CreateTemp("", fmt.Sprintf("%s-*.jpg", doc.PatientID))
+	if err != nil {
+		return nil, fmt.Errorf("unable to create tempFile. %w", err)
+	}
+
+	u, err := i.getDocumentURL(doc.DownloadURL)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Println("Downloading file...")
+	err = i.downloadFile(ctx, u, tmpFile)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = tmpFile.Seek(0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("unable to seek to beginning of temp file. %w", err)
+	}
+
+	return tmpFile, nil
+}
+
+func (i *WebIntegration) downloadFile(ctx context.Context, u *url.URL, w io.Writer) error {
+	req, err := http.NewRequest(http.MethodGet, u.String(), http.NoBody)
+	if err != nil {
+		return fmt.Errorf("unable to create request to download file. %w", err)
+	}
+
+	resp, err := i.client.Do(req.WithContext(ctx))
+	if err != nil {
+		return fmt.Errorf("unable to make request to download file. %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("invalid status code received. %w StatusCode: %d", err, resp.StatusCode)
+	}
+
+	_, err = io.Copy(w, resp.Body)
+	if err != nil {
+		return fmt.Errorf("unable to copy payload to writer. %w", err)
+	}
+
+	return nil
+}
+
+func (i *WebIntegration) getDocumentURL(downloadURL string) (*url.URL, error) {
+	u, err := url.Parse(downloadURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid download url provided. %w", err)
+	}
+	return u, nil
+}

--- a/refactored-carsonoid/integrations/web_test.go
+++ b/refactored-carsonoid/integrations/web_test.go
@@ -1,0 +1,118 @@
+package integrations
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestWebIntegration_DownloadDocument(t *testing.T) {
+	validDownloadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte("test file contents"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer validDownloadServer.Close()
+
+	invalidDownloadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(300)
+	}))
+	defer validDownloadServer.Close()
+
+	type fields struct {
+		client *http.Client
+	}
+	type args struct {
+		ctx context.Context
+		doc *Document
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		args     args
+		wantBody []byte
+		wantErr  bool
+	}{
+		{
+			name: "bad url",
+			fields: fields{
+				&http.Client{Timeout: time.Second * 3},
+			},
+			args: args{
+				ctx: context.Background(),
+				doc: &Document{
+					DownloadURL: "",
+				},
+			},
+			wantBody: nil,
+			wantErr:  true,
+		},
+		{
+			name: "downloadFail",
+			fields: fields{
+				&http.Client{Timeout: time.Second * 3},
+			},
+			args: args{
+				ctx: context.Background(),
+				doc: &Document{
+					DownloadURL: invalidDownloadServer.URL,
+				},
+			},
+			wantBody: nil,
+			wantErr:  true,
+		},
+		{
+			name: "success",
+			fields: fields{
+				&http.Client{Timeout: time.Second * 3},
+			},
+			args: args{
+				ctx: context.Background(),
+				doc: &Document{
+					DownloadURL: validDownloadServer.URL,
+				},
+			},
+			wantBody: []byte("test file contents"),
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &WebIntegration{
+				client: tt.fields.client,
+			}
+			gotFile, err := i.DownloadDocument(tt.args.ctx, tt.args.doc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("WebIntegration.DownloadDocument() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if gotFile == nil {
+				if tt.wantBody != nil {
+					t.Errorf("WebIntegration.DownloadDocument() = %v, want %v", gotFile, tt.wantBody)
+				}
+				return
+			}
+
+			defer gotFile.Close()
+			defer os.Remove(gotFile.Name())
+
+			// read the body
+			body, err := io.ReadAll(gotFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(body, tt.wantBody) {
+				t.Errorf("WebIntegration.DownloadDocument() = %v, want %v", string(body), string(tt.wantBody))
+			}
+		})
+	}
+}

--- a/refactored-carsonoid/main.go
+++ b/refactored-carsonoid/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/bradleyshawkins/go-clean-architecture/refactored-carsonoid/handlers"
+)
+
+func main() {
+	mux := handlers.NewMux()
+
+	fmt.Println("Starting router...")
+	err := http.ListenAndServe(":8080", mux)
+	if err != nil {
+		fmt.Printf("Error received: %v\n", err)
+	}
+}


### PR DESCRIPTION
This is a more minimal refactor of the code than the original proposed refactor. It might still be over-engineered but most of the changes are made based on the original idea that the code here is representative of a larger code base that needs to grow.

I've tried to make judicious use of interfaces to abstract just enough while not making the code to java-esque. If this code base did grow massively then it might make sense to break out the `integrations` package into multiple smaller packages and to move the 'Document' struct out of the `interfaces` package as well.